### PR TITLE
fix .swc validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ slurm
 .vscode/
 .ipynb_checkpoints
 *.egg-info
+.*/
 
 # C extensions
 *.so
@@ -72,3 +73,4 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # datasets/docs
-data*
-runs
-external
-slurm
+/data*
+/runs
+/external
+/slurm
 *.csv
 *.pt
 *.pth
@@ -13,7 +13,7 @@ slurm
 .vscode/
 .ipynb_checkpoints
 *.egg-info
-.*/
+.cursor/
 
 # C extensions
 *.so

--- a/deep_neuronmorpho/data/process_swc.py
+++ b/deep_neuronmorpho/data/process_swc.py
@@ -104,12 +104,10 @@ class SWCData:
         float_cols = ["x", "y", "z", "radius"]
         col_type = dict.fromkeys(int_cols, int) | dict.fromkeys(float_cols, float)
         data = data.astype(col_type)
-        # only soma nodes (type=1) should have -1 as parent
-        mask = data["type"] != 1
-        data.loc[mask, "parent"] = data.loc[mask, "parent"].abs()
-        # validate swc file
-        assert not data.query("parent == 1 and (type == 3 or type == 4)").empty, (
-            "Bad SWC file: No dendrites connected to soma!"
+        # any nodes with parent == -1 should be type 1 (soma)
+        data.loc[data["parent"] == -1, "type"] = 1
+        assert (data["parent"] == -1).any(), (
+            "SWC file must contain at least one root node with parent == -1"
         )
 
         return data


### PR DESCRIPTION
This PR fixes .swc file validation.

## Problem
NeuroMorpho.org does not enforce validation of .swc files. Therefore, some files are not "technically" valid. For example, some files (auto-converted using tools like L-measure) have a node that looks like the soma (i.e., parent id = -1), but the wrong type (type = 3). This was breaking our validation check. This fix auto assigns ANY node with a parent id of -1 to the soma type.