### PR TITLE
simplify MACGNN implementation

### DIFF
--- a/deep_neuronmorpho/data/datasets.py
+++ b/deep_neuronmorpho/data/datasets.py
@@ -159,6 +159,7 @@ class ContrastiveNeuronDataset(Dataset):
     Wrapper dataset that takes single Data object and returns two contrastive views.
     """
 
+    # TODO: recompute all features after transform
     def __init__(self, dataset: Dataset, transform: Callable):
         self.dataset = dataset
         self.transform = transform
@@ -169,6 +170,6 @@ class ContrastiveNeuronDataset(Dataset):
     def __getitem__(self, idx: int) -> tuple[Data, Data]:
         data = self.dataset[idx]
         g1, g2 = self.transform(data.clone()), self.transform(data.clone())
-        g1.x, g2.x = g1.pos, g2.pos
+        g1.x[:, :3], g2.x[:, :3] = g1.pos, g2.pos
 
         return g1, g2

--- a/deep_neuronmorpho/engine/ntxent_loss.py
+++ b/deep_neuronmorpho/engine/ntxent_loss.py
@@ -14,9 +14,9 @@ class NTXEntLoss:
 
     Inputs:
         - embed_a (Tensor): A tensor of shape `(batch_size, embedding_dim)`
-        containing the embeddings for the original data.
+        containing the embeddings for the view 1 data.
         - embed_b (Tensor): A tensor of shape `(batch_size, embedding_dim)`
-        containing the embeddings for the augmented data.
+        containing the embeddings for the view 2 data.
 
     Returns:
         Tensor: A scalar tensor containing the computed loss value.

--- a/deep_neuronmorpho/models/model_utils.py
+++ b/deep_neuronmorpho/models/model_utils.py
@@ -11,8 +11,8 @@ from torch_geometric.nn import global_add_pool, global_max_pool, global_mean_poo
 def aggregate_tensor(
     tensor_data: Tensor,
     aggregation_method: str = "cat",
-    dim: int = -1,
     weights: Tensor | None = None,
+    dim: int = -1,
 ) -> Tensor:
     """Aggregates tensor data along a given dimension according to the specified aggregation method.
 
@@ -32,7 +32,7 @@ def aggregate_tensor(
         NotImplementedError: If the aggregation method is not implemented.
     """
 
-    def wsum(tensor_data: Tensor, weights: Tensor, dim: int = -1) -> Tensor:
+    def wsum(tensor_data: Tensor, weights: Tensor | None, dim: int = -1) -> Tensor:
         if weights is None:
             raise ValueError("weights cannot be None for weighted sum aggregation.")
 


### PR DESCRIPTION
This pull request refactors and simplifies the `MACGNN` and `GIN` models, clarifies documentation, and makes targeted adjustments to the contrastive dataset. The most significant changes include simplifying the stream handling in `MACGNN`, updating the `GIN` model's forward method for greater flexibility, and clarifying loss documentation.

**Model architecture and refactoring:**

* Refactored `MACGNN` to use two explicit GIN streams (`geo_gnn` and `topo_gnn`) instead of a dynamic `gnn_streams` dictionary, simplifying stream management and aggregation logic. Now, geometry and topology streams are handled directly, and aggregation uses a unified tensor stack. [[1]](diffhunk://#diff-c6d4b311303229d223e9cff792060d20e12a06d19335ea4d55b66fcd70c2e2e4L23-R55) [[2]](diffhunk://#diff-c6d4b311303229d223e9cff792060d20e12a06d19335ea4d55b66fcd70c2e2e4L115-R119)
* Updated the `GIN` model's `forward` method to accept an optional `x` tensor of node features and a more general `feat_index` argument, improving flexibility for different input types. [[1]](diffhunk://#diff-c326066072064397e55969cb23b342d8680e048171c16e006ffb98ac3530ce8bL75-R82) [[2]](diffhunk://#diff-c326066072064397e55969cb23b342d8680e048171c16e006ffb98ac3530ce8bL84-R100)

**Loss and dataset improvements:**

* Clarified documentation in `NTXEntLoss` to specify that `embed_a` and `embed_b` refer to "view 1" and "view 2" data, respectively, improving understandability for contrastive learning.
* In `ContrastiveNeuronDataset`, adjusted the assignment of node features so that only the first three dimensions of `x` are set to positions, ensuring compatibility with downstream processing.
* Added a TODO note in `ContrastiveNeuronDataset` to remind that all features should be recomputed after transformation, highlighting an area for future improvement.